### PR TITLE
amins: fix channel delete route

### DIFF
--- a/amnis/delivery/http/routes.go
+++ b/amnis/delivery/http/routes.go
@@ -61,7 +61,7 @@ func removeDuplicateKeywords(keywords []string) []string {
 
 func delete(c *gin.Context) {
 	id := c.Param("id")
-	err := domain.Delete(id, c.GetInt("uid"))
+	err := domain.Delete(id, int(c.GetInt64("uid")))
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": "could not delete channel",


### PR DESCRIPTION
The `DELETE /api/channels/:id ` route did not function due to a type conversion error. This pr fixes that.
